### PR TITLE
优化TCP重连的策略

### DIFF
--- a/src/TouchSocket/Sockets/Extensions/SocketPluginsManagerExtension.cs
+++ b/src/TouchSocket/Sockets/Extensions/SocketPluginsManagerExtension.cs
@@ -37,6 +37,7 @@ namespace TouchSocket.Core.Plugins
         public static IPluginsManager UseReconnection(this IPluginsManager pluginsManager, int tryCount = 10, 
             bool printLog = false, int sleepTime = 1000, Action<ITcpClient> successCallback = null)
         {
+            bool first = true;
             var reconnectionPlugin = new ReconnectionPlugin<ITcpClient>(client=> 
             {
                 int tryT = tryCount;
@@ -50,9 +51,11 @@ namespace TouchSocket.Core.Plugins
                         }
                         else
                         {
+                            if (first) Thread.Sleep(1000);
+                            first = false;
                             client.Connect();
+                            first = true;
                         }
-
                         successCallback?.Invoke(client);
                         return true;
                     }
@@ -85,6 +88,7 @@ namespace TouchSocket.Core.Plugins
             Func<ITcpClient,int,Exception,bool> failCallback=null,
             Action<ITcpClient> successCallback = null)
         {
+            bool first = true;
             var reconnectionPlugin = new ReconnectionPlugin<ITcpClient>(client =>
             {
                 int tryT = 0;
@@ -98,7 +102,10 @@ namespace TouchSocket.Core.Plugins
                         }
                         else
                         {
+                            if (first) Thread.Sleep(1000);
+                            first = false;
                             client.Connect();
+                            first = true;
                         }
 
                         successCallback?.Invoke(client);


### PR DESCRIPTION
在启用TCP重连的情况下
本地开发时，服务端跟客户端在同一台机器上，主动关闭服务端的情况时，客户端会马上重边，并且连上了服务端，但服务端随后就关闭了，后续无法触发重连。应该是本地开发，延时很低，服务端还没释放完造成。如果服务端部署在服务器上，也许网络很好的情况下也会出现？因为在第一次重连时加个休眠好一点？