### PR TITLE
修复TcpService停止服务时未触发ServiceStateEventArgs事件

### DIFF
--- a/src/TouchSocket/Components/Tcp/TcpServiceBaseT.cs
+++ b/src/TouchSocket/Components/Tcp/TcpServiceBaseT.cs
@@ -215,12 +215,10 @@ namespace TouchSocket.Sockets
         public override async Task StopAsync()
         {
             this.ThrowIfDisposed();
-
-            this.m_serverState = ServerState.Stopped;
-            await this.ReleaseAll().ConfigureAwait(false);
-
             if (this.m_serverState == ServerState.Running)
             {
+                this.m_serverState = ServerState.Stopped;
+                await this.ReleaseAll().ConfigureAwait(false);
                 await this.PluginManager.RaiseAsync(typeof(IServerStopedPlugin), this, new ServiceStateEventArgs(this.m_serverState, default)).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
Hi，若汝棋茗：
修复了一个bug：TcpService停止服务时未触发IServerStopedPlugin插件行为的ServiceStateEventArgs事件