### PR TITLE
fix: 添加 ConfigureAwait 配置, 修复同步等待方法挂起问题

### DIFF
--- a/src/TouchSocket.Core/Extensions/SystemExtension.cs
+++ b/src/TouchSocket.Core/Extensions/SystemExtension.cs
@@ -930,7 +930,9 @@ public static class SystemExtension
     public static async Task WriteAsync(this Stream stream, ReadOnlyMemory<byte> memory, CancellationToken token)
     {
         var segment = memory.GetArray();
-        await stream.WriteAsync(segment.Array, segment.Offset, segment.Count, token);
+
+        await stream.WriteAsync(segment.Array, segment.Offset, segment.Count, token)
+            .ConfigureAwait(EasyTask.ContinueOnCapturedContext);
     }
 
     /// <summary>


### PR DESCRIPTION
## fix: 添加 ConfigureAwait 配置, 修复同步等待方法挂起问题

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

Modbus Rtu Master 中同步等待方法因缺少 ConfigAwait 相关配置, 导致读取时挂起, 卡住 UI 界面
